### PR TITLE
Fixed blank screen issue with newer GLM-0.9.9.x releases

### DIFF
--- a/batch-draw.cpp
+++ b/batch-draw.cpp
@@ -155,7 +155,7 @@ void draw_batchDrawArrays(void *data, struct wl_callback *callback, uint32_t tim
 	glUniform1f(win->gl_single.loop_count_short, win->shortShader_loop_count);
 
 	// set the pyramid rotation matrix
-	glm::mat4 identity_matrix;
+	glm::mat4 identity_matrix(1.f);
 	glm::mat4 model_matrix = glm::rotate(identity_matrix, angle*(3.14f/180.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 	glUniformMatrix4fv(win->gl_single.rotation_uniform, 1, GL_FALSE,
 			   (GLfloat *) glm::value_ptr(model_matrix));

--- a/long-shader.cpp
+++ b/long-shader.cpp
@@ -155,7 +155,7 @@ void draw_longShader(void *data, struct wl_callback *callback, uint32_t time_now
 	glEnableVertexAttribArray(win->gl_longShader.tex1);
 
 	// fullscreen quad
-	glm::mat4 identity_matrix;
+	glm::mat4 identity_matrix(1.f);
 	glm::mat4 model_matrix = glm::rotate(identity_matrix, angle*(3.14159265f/180.0f), glm::vec3(0.0f, 0.0f, 1.0f));
 	glUniformMatrix4fv(win->gl_longShader.rotation_uniform, 1, GL_FALSE, (GLfloat *)glm::value_ptr(model_matrix));
 

--- a/multi-draw.cpp
+++ b/multi-draw.cpp
@@ -160,7 +160,7 @@ void draw_multiDrawArrays (void* data, struct wl_callback* callback, uint32_t ti
 		{
 			for(int y=0; y<y_count; y++)			
 			{				
-				glm::mat4 model_matrix;
+				glm::mat4 model_matrix(1.f);
 				model_matrix = glm::translate(model_matrix, glm::vec3((float)x*3, (float)y*3, (float)z*3));
 				model_matrix = glm::rotate(model_matrix, angle*3.14f/180.0f, glm::vec3(0.0f, 1.0f, 0.0f));
 				glUniformMatrix4fv(win->gl_multi.rotation_uniform, 1, GL_FALSE,

--- a/simple-dial.cpp
+++ b/simple-dial.cpp
@@ -221,8 +221,8 @@ void draw_simpleDial(void *data, struct wl_callback *callback, uint32_t time_now
 	glEnableVertexAttribArray(win->gl_tex.tex1);
 			
 		// left dial				
-		glm::mat4 model_matrix;
-		glm::mat4 identity_matrix;
+		glm::mat4 model_matrix(1.f);
+		glm::mat4 identity_matrix(1.f);
 		model_matrix = glm::translate(identity_matrix, glm::vec3(-0.5f, 0.0f, 0.0f));
 		model_matrix = glm::scale(model_matrix, glm::vec3(aspect_ratio * shrink, 1.0f * shrink, 1.0f));				
 		glUniformMatrix4fv(win->gl_tex.rotation_uniform, 1, GL_FALSE,

--- a/simple-texture.cpp
+++ b/simple-texture.cpp
@@ -274,10 +274,10 @@ void draw_simpleTexture(void *data, struct wl_callback *callback, uint32_t time_
 			
 	// fullscreen quad
 	if(win->texture_flat_no_rotate)	{		
-		model_matrix = glm::mat4();
+		model_matrix = glm::mat4(1.f);
 	} else {
 		//model_matrix = rotate(angle, 0.0f, 1.0f, 0.0f);
-		model_matrix = glm::mat4();		
+		model_matrix = glm::mat4(1.f);		
 	}
 	
 	glUniformMatrix4fv(win->gl_tex.rotation_uniform, 1, GL_FALSE,

--- a/single-draw.cpp
+++ b/single-draw.cpp
@@ -154,7 +154,7 @@ void draw_singleDrawArrays(void *data, struct wl_callback *callback, uint32_t ti
 	glUniform1f(win->gl_single.loop_count_short, win->shortShader_loop_count);
 
 	// set the pyramid rotation matrix
-	glm::mat4 identity_matrix;
+	glm::mat4 identity_matrix(1.f);
 	glm::mat4 model_matrix = glm::rotate(identity_matrix, angle*(3.14f/180.0f), glm::vec3(0.0f, 1.0f, 0.0f));
 	glUniformMatrix4fv(win->gl_single.rotation_uniform, 1, GL_FALSE,
 			   (GLfloat *) glm::value_ptr(model_matrix));


### PR DESCRIPTION
GLM no longer default initializes matrix types as of GLM 0.9.9.x. Added explicit initialize to the glm::mat4 constructors so they default to identity.