### PR TITLE
Added ability to pass an EGL priority hint during context creation.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -53,6 +53,7 @@ textRender g_TextRender;
 std::ofstream g_metricsfile;
 bool g_recordMetrics = false;
 DrawCases g_draw_case = simpleDial;
+eContextPriority g_contextPriority = eContextPriority::Medium;
 static bool g_Initalized = false;
 unsigned int g_FramesToRender = 0;
 
@@ -646,6 +647,31 @@ int read_config_file(char* config_filename)
 	std::getline(infile, line);		
 	g_window.fullscreen = safeParse(line, 1);
 	printf("Window running fullscreen = %s\n", (g_window.fullscreen) ? "true" : "false" );
+
+	// EGL priority hint
+	std::getline(infile, line);
+	printf("Context priority: ");
+	switch(line[0])
+	{
+		case 'h':
+		case 'H':
+			g_contextPriority = eContextPriority::High;
+			printf("high\n");
+			break;
+	
+		case 'l':
+		case 'L':
+			g_contextPriority = eContextPriority::Low;
+			printf("low\n");
+			break;
+
+		case 'm':
+		case 'M':
+		default:
+			g_contextPriority = eContextPriority::Medium;
+			printf("medium\n");
+			break;
+	};
 
 	// record metrics to a file?
 	std::getline(infile, line);		

--- a/main.h
+++ b/main.h
@@ -54,6 +54,13 @@ enum DrawCases {
 	next_case,
 };
 
+// EGL priority hint
+enum eContextPriority {
+	High = 0,	
+	Medium = 1,
+	Low = 2,
+};
+
 
 // Opengl and surface/window structs
 struct output {
@@ -201,6 +208,7 @@ class textRender;
 
 // globals
 extern DrawCases g_draw_case;
+extern eContextPriority g_contextPriority;
 extern bool g_demo_mode;
 
 // pyramid geometry parameters

--- a/params.txt
+++ b/params.txt
@@ -1,6 +1,7 @@
 1920 	 // window width
 1080 	 // window height
 1	 // fullscreen mode
+m	 // EGL priority hint: h=high, m=medium, l=low
 0	 // save per-frame metrics
 0	 // draw to offscreen buffer (0=onscreen, 1=offscreen)
 0	 // vsync 0=off, 1=on

--- a/simple-egl-windowing.h
+++ b/simple-egl-windowing.h
@@ -76,8 +76,9 @@ static output* get_default_output(display *display)
 
 static void init_egl(display *display, window *window)
 {
-	static const EGLint context_attribs[] = {
+	static EGLint context_attribs[] = {
 		EGL_CONTEXT_CLIENT_VERSION, 2,
+		EGL_CONTEXT_PRIORITY_LEVEL_IMG, EGL_CONTEXT_PRIORITY_MEDIUM_IMG,
 		EGL_NONE
 	};
 	const char *extensions;
@@ -114,6 +115,26 @@ static void init_egl(display *display, window *window)
 
 	configs = (EGLConfig*) calloc(count, sizeof *configs);
 	assert(configs);
+
+	switch(g_contextPriority) 
+	{
+		case eContextPriority::High:
+			context_attribs[3] = EGL_CONTEXT_PRIORITY_HIGH_IMG;	
+			break;
+
+		case eContextPriority::Low:
+			context_attribs[3] = EGL_CONTEXT_PRIORITY_LOW_IMG;
+			break;
+
+		case eContextPriority::Medium:
+			context_attribs[3] = EGL_CONTEXT_PRIORITY_MEDIUM_IMG;
+			break;
+
+		default:
+			printf("Error setting context priority\n");
+			exit(0);
+	}
+
 
 	ret = eglChooseConfig(display->egl.dpy, config_attribs,
 			      configs, count, &n);


### PR DESCRIPTION
Adding the ability to pass along a IMG_context_priority via the params.txt file. 

You can now specify the parameter in the params.txt file. Entry line 3 is the parameter:
h = EGL_CONTEXT_PRIORITY_HIGH_IMG
m = EGL_CONTEXT_PRIORITY_MEDIUM_IMG
l = EGL_CONTEXT_PRIORITY_LOW_IMG

https://www.khronos.org/registry/EGL/extensions/IMG/EGL_IMG_context_priority.txt